### PR TITLE
Get maven to compile project after a fresh clone

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <mainClass>ReportMerger</mainClass>
+                    <mainClass>com.gk.test.ReportMerger</mainClass>
                     <arguments>
                         <argument>target/cucumber-report/</argument>
                     </arguments>


### PR DESCRIPTION
I needed this simple change in order to successfully run `mvn clean install -DskipTests`. 